### PR TITLE
Trim description before printing first line since there could be leading `\n` from multi-line template strings.

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -126,7 +126,7 @@ export default abstract class Command {
   protected _help() {
     const HHelp: typeof Help = require('@oclif/plugin-help').default
     const help = new HHelp(this.config)
-    let title = this.ctor.description && help.render(this.ctor.description).split('\n')[0]
+    let title = this.ctor.description && help.render(this.ctor.description.trim()).split('\n')[0]
     if (title) this.log(title + '\n')
     this.log(help.command(Config.Command.toCached(this.ctor as any as Config.Command.Class)))
     return this.exit(0)


### PR DESCRIPTION
Apologies for not including a test, but I wasn't quite sure where to put it: here, or in `@oclif/plugin-help`, or maybe in `example-multi-js`. 

Lost quite a bit of time trying to figure this one out. The symptom is `mycli --help` displaying nothing for a given command.

The root cause around how template strings are interpreted.

If [this description](https://github.com/oclif/example-multi-js/blob/master/src/commands/goodbye.js#L11-L14) has a leading `\n`, e.g:

``` js
GoodbyeCommand.description = `
Describe the command here
...
Extra documentation goes here
`;
```

Then `mycli --help` will *display nothing* for that command. By trimming off any whitespace before parsing we ensure that this "gotcha" will be avoided by folks new to the framework.