### PR TITLE
Space-separated subcommands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,13 +15,32 @@ export class Main extends Command {
   }
 
   async run() {
-    let [id, ...argv] = this.argv
+    const {id, argv} = this.splitArgv()
     this.parse({strict: false, '--': false, ...this.ctor as any})
     if (!this.config.findCommand(id)) {
       let topic = this.config.findTopic(id)
       if (topic) return this._help()
     }
     await this.config.runCommand(id, argv)
+  }
+
+  splitArgv() {
+    // For example, if this.argv is ['user', 'add', 'Peter'] and this.config.commandIDs
+    // contain the 'user add' command, this function returns {id: 'user add', argv: ['Peter']}
+    let argvIndex = 0
+    let id = ''
+    let idCandidate = this.argv[argvIndex]
+
+    while (this.config.commandIDs.includes(idCandidate)) {
+      id = idCandidate
+      argvIndex++
+      idCandidate += ` ${this.argv[argvIndex]}`
+    }
+
+    return {
+      id,
+      argv: this.argv.slice(argvIndex),
+    }
   }
 
   protected _helpOverride(): boolean {


### PR DESCRIPTION
This PR adds support for space-separated subcommands at the @oclif/command level. The support also needs to be added in @oclif/config or possibly via plugin, I'm not sure yet – I'll open a PR in @oclif/config to show one way to do it.

The change is rather small and backwards-compatible with colon-separated topics, here is a copy of the commit description:

---

Previously, `Main.run` considered the first item in `argv` array a command ID, for example, in the `['user:add', 'Peter']` array, the command was `user:add` and the rest were its args. This doesn't work with space-separated commands which produce `argv` array like this:

```
['user', 'add', 'Peter']
```

and would be parsed as a `user` command that gets `add` and `Peter` as args.

The new implementation looks at `config.commandIDs` and tries to find the longest match with items from `argv`. For example, if `commandIDs` contained `user` and `user add` commands, the new implementation would invoke a `user add` command with `['Peter']` as args. If, on the other hand, `commandIds` only contained the `user` command, it would invoke a `user` command with `['add', 'Peter']` as args.

A couple of notes:

- It's up to @oclif/config (or possibly a plugin) to produce command IDs that contain spaces. As of @oclif/config@1.9.0, the command IDs contain a colon, e.g., `user:add`.
- The change is backwards compatible. Argv `['user:add', 'Peter']` is still parsed as command ID `user:add` and `['Peter']` as args.
- The command separator is currently hardcoded to be a space. If oclif introduced a new config option like `"separator": "<any_character>"`, the argv splitting logic should be updated.
- The `splitArgv` function should be unit-tested. I didn't find a testing infrastructure in this package, will seek advice on how to best do it.