### PR TITLE
Adds JSDoc comments to the static vars on the Config

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,5 @@
 // tslint:disable no-implicit-dependencies
+// tslint:disable no-single-line-block-comment
 const pjson = require('../package.json')
 import * as Config from '@oclif/config'
 import * as Errors from '@oclif/errors'
@@ -8,20 +9,38 @@ import {format, inspect} from 'util'
 
 import * as flags from './flags'
 
+/**
+ * An abstract class which acts as the base for each command
+ * in your project.
+ */
+
 export default abstract class Command {
   static _base = `${pjson.name}@${pjson.version}`
+  /** A command ID, used mostly in error or verbose reporting */
   static id: string
+  // TODO: Confirm unused?
   static title: string | undefined
+  /**
+   * The tweet-sized description for your class, used in a parent-commands
+   * sub-command listing and as the header for the command help
+   */
   static description: string | undefined
+  /** hide the command from help? */
   static hidden: boolean
+  /** An override string (or strings) for the default usage documentation */
   static usage: string | string[] | undefined
   static help: string | undefined
+  /** An array of aliases for this command */
   static aliases: string[] = []
+  /** When set to false, allows a variable amount of arguments */
   static strict = true
   static parse = true
+  /** A hash of flags for the command */
   static flags?: flags.Input<any>
+  /** An order-dependent array of arguments for the command */
   static args?: Parser.args.IArg[]
   static plugin: Config.IPlugin | undefined
+  /** An array of example strings to show at the end of the command's help */
   static examples: string[] | undefined
   static parserOptions = {}
 


### PR DESCRIPTION
Covered some of the fields with inline docs.

I couldn't find `parse` or title` being used in oclif CLI, or in here, so I made a note for myself, should I just removed the TODO?