### PR TITLE
Make @oclif/config a prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/oclif/command/issues",
   "dependencies": {
+    "@oclif/config": "^1.12.10",
     "@oclif/errors": "^1.2.2",
     "@oclif/parser": "^3.7.3",
     "debug": "^4.1.1",
     "semver": "^5.6.0"
   },
   "devDependencies": {
-    "@oclif/config": "^1.12.10",
     "@oclif/plugin-help": "^2.1.6",
     "@oclif/plugin-plugins": "^1.7.7",
     "@oclif/tslint": "^3.1.1",


### PR DESCRIPTION
This PR makes `@oclif/config` a prod dependency rather than a dev dependency. The motivation is to fix monorepo projects whose dependencies are managed by pnpm, since pnpm isolates each monorepo project's dependency's dependencies.

Context: when using yarn or npm, `@oclif/config` is visible to `@oclif/command` because it's a prod dependency for `oclif` (i.e., https://github.com/oclif/oclif/blob/master/package.json#L10) and `node_modules` has a flat structure. However, with pnpm monorepos, `oclif`'s dependencies and `@oclif/command`'s dependencies are isolated from each other, and so `@oclif/config` isn't visible to `@oclif/command`.

I believe that this behavior is not only helpful for those of us using pnpm, it also implements the correct behavior since `@oclif/config` is called at runtime and should therefore be properly considered a prod dependency.

Fixes https://github.com/oclif/command/issues/59