### PR TITLE
fix: remove stdout error listener as a member instance

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -11,6 +11,16 @@ import * as flags from './flags'
 import {sortBy, uniqBy} from './util'
 
 /**
+ * swallows stdout epipe errors
+ * this occurs when stdout closes such as when piping to head
+ */
+process.stdout.on('error', err => {
+  if (err && err.code === 'EPIPE')
+    return
+  throw err
+})
+
+/**
  * An abstract class which acts as the base for each command
  * in your project.
  */
@@ -113,7 +123,6 @@ export default abstract class Command {
     const g: any = global
     g['http-call'] = g['http-call'] || {}
     g['http-call']!.userAgent = this.config.userAgent
-    this._swallowEPIPE()
     if (this._helpOverride()) return this._help()
   }
 
@@ -169,16 +178,5 @@ export default abstract class Command {
   protected _version() {
     this.log(this.config.userAgent)
     return this.exit(0)
-  }
-
-  /**
-   * swallows stdout epipe errors
-   * this occurs when stdout closes such as when piping to head
-   */
-  protected _swallowEPIPE() {
-    process.stdout.on('error', err => {
-      if (err && err.code === 'EPIPE') return
-      throw err
-    })
   }
 }

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -294,7 +294,7 @@ USAGE
         await CMD.run([])
       })
       .catch(/dd/)
-      .it('test epipe pass')
+      .it('test stdout error throws')
 
     fancy
       .stdout()
@@ -308,6 +308,6 @@ USAGE
         await CMD.run([])
       })
       .do(ctx => expect(ctx.stdout).to.equal('json output: {"a":"foobar"}\n'))
-      .it('test epipe pass')
+      .it('test stdout EPIPE swallowed')
   })
 })

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -14,6 +14,12 @@ class Command extends Base {
   }
 }
 
+class CodeError extends Error {
+  constructor(private readonly code: string) {
+    super(code)
+  }
+}
+
 describe('command', () => {
   fancy
     .stdout()
@@ -274,5 +280,34 @@ USAGE
       })
       .do(ctx => expect(ctx.stdout).to.equal('json output: {"a":"foobar"}\n'))
       .it('uses util.format()')
+  })
+
+  describe('stdout err', () => {
+    fancy
+      .stdout()
+      .do(async () => {
+        class CMD extends Command {
+          async run() {
+            process.stdout.emit('error', new CodeError('dd'))
+          }
+        }
+        await CMD.run([])
+      })
+      .catch(/dd/)
+      .it('test epipe pass')
+
+    fancy
+      .stdout()
+      .do(async () => {
+        class CMD extends Command {
+          async run() {
+            process.stdout.emit('error', new CodeError('EPIPE'))
+            this.log('json output: %j', {a: 'foobar'})
+          }
+        }
+        await CMD.run([])
+      })
+      .do(ctx => expect(ctx.stdout).to.equal('json output: {"a":"foobar"}\n'))
+      .it('test epipe pass')
   })
 })


### PR DESCRIPTION
This is to fix:

https://github.com/oclif/command/issues/64