### PR TITLE
fix: sync types with @oclif/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/oclif/command/issues",
   "dependencies": {
     "@oclif/errors": "^1.2.2",
-    "@oclif/parser": "^3.7.3",
+    "@oclif/parser": "^3.8.3",
     "debug": "^4.1.1",
     "semver": "^5.6.0"
   },

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -28,7 +28,7 @@ export type Input<T extends Parser.flags.Output> = { [P in keyof T]: IFlag<T[P]>
 
 export type Definition<T> = {
   (options: {multiple: true} & Partial<IOptionFlag<T>>): IOptionFlag<T[]>
-  (options: {required: true} & Partial<IOptionFlag<T>>): IOptionFlag<T>
+  (options: ({required: true} | {default: Parser.flags.Default<T>}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
   (options?: Partial<IOptionFlag<T>>): IOptionFlag<T | undefined>
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,13 +86,13 @@
     chalk "^2.4.1"
     tslib "^1.9.3"
 
-"@oclif/parser@^3.7.3":
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.7.3.tgz#cb2240f457396e7b1af2f13caa0dca85b92a5a37"
-  integrity sha512-yfYpDzVn9ipo4HZtYLfMtd3j3ArpTQlRbQfy9pNnHFd4VedE2PNYQTRWYYMuu1FxEOoknlMZbzsewVvl41TvKg==
+"@oclif/parser@^3.8.3":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.3.tgz#717fbbe5bfafef4270224b8bd41a2d3c80b9554e"
+  integrity sha512-zN+3oGuv9Lg8NjFvxZTDKFEmhAMfAvd/JWeQp3Ri8pDezoyJQi4OSHHLM8sdHjBh8sePewfWI7+fDUXdrVbrqg==
   dependencies:
     "@oclif/linewrap" "^1.0.0"
-    chalk "^2.4.1"
+    chalk "^2.4.2"
     tslib "^1.9.3"
 
 "@oclif/plugin-help@^2.1.6":


### PR DESCRIPTION
This incorporates the changes from https://github.com/oclif/parser/pull/53.

It's a pity that this has to be manually kept in sync. I tried coming up with a way to keep them in sync automatically by reusing the types from the other package but I couldn't think of any solutions that didn't involve big changes. Any ideas?