### PR TITLE
fix: `default` should be `T[]` when `multiple: true`

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -27,7 +27,7 @@ export type Output = Parser.flags.Output
 export type Input<T extends Parser.flags.Output> = { [P in keyof T]: IFlag<T[P]> }
 
 export type Definition<T> = {
-  (options: {multiple: true} & Partial<IOptionFlag<T>>): IOptionFlag<T[]>
+  (options: {multiple: true} & Partial<IOptionFlag<T[]>>): IOptionFlag<T[]>
   (options: ({required: true} | {default: Parser.flags.Default<T>}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
   (options?: Partial<IOptionFlag<T>>): IOptionFlag<T | undefined>
 }


### PR DESCRIPTION
Complementary pull request to https://github.com/oclif/parser/pull/56.