### PR TITLE
Enable support for a "default command"

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -72,6 +72,7 @@ export default abstract class Command {
    * @param {Config.Command.Class} this Class
    * @param {string[]} argv argv
    * @param {Config.LoadOptions} opts options
+   * @param {Config.Command.RunOptions} runOptions run options
    */
   static run: Config.Command.Class['run'] = async function (this: Config.Command.Class, argv?: string[], opts?,
       runOptions?: Config.Command.RunOptions) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -73,18 +73,19 @@ export default abstract class Command {
    * @param {string[]} argv argv
    * @param {Config.LoadOptions} opts options
    */
-  static run: Config.Command.Class['run'] = async function (this: Config.Command.Class, argv?: string[], opts?) {
+  static run: Config.Command.Class['run'] = async function (this: Config.Command.Class, argv?: string[], opts?,
+      runOptions?: Config.Command.RunOptions) {
     if (!argv) argv = process.argv.slice(2)
     const config = await Config.load(opts || (module.parent && module.parent.parent && module.parent.parent.filename) || __dirname)
-    const cmd = new this(argv, config)
-    return cmd._run(argv)
+    const cmd = new this(argv, config, runOptions)
+    return cmd._run(argv, runOptions)
   }
 
   id: string | undefined
 
   protected debug: (...args: any[]) => void
 
-  constructor(public argv: string[], public config: Config.IConfig) {
+  constructor(public argv: string[], public config: Config.IConfig, public options?: Config.Command.RunOptions) {
     this.id = this.ctor.id
     try {
       this.debug = require('debug')(this.id ? `${this.config.bin}:${this.id}` : this.config.bin)
@@ -95,6 +96,10 @@ export default abstract class Command {
 
   get ctor(): typeof Command {
     return this.constructor as typeof Command
+  }
+
+  get isBeingRunByDefault() {
+    return !!this.options && !!this.options.isBeingRunByDefault
   }
 
   async _run<T>(): Promise<T | undefined> {

--- a/src/command.ts
+++ b/src/command.ts
@@ -159,6 +159,12 @@ export default abstract class Command {
     return require('@oclif/parser').parse(argv, {context: this, ...options})
   }
 
+  protected get _defaultCommandId(): string | undefined {
+    return (this.config.pjson.oclif as {
+      defaultCommand?: string
+    }).defaultCommand
+  }
+
   protected async catch(err: any): Promise<any> {
     if (!err.message) throw err
     if (err.message.match(/Unexpected arguments?: (-h|--help|help)(,|\n)/)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export class Main extends Command {
   }
 
   protected _runDefaultCommand() {
-    return this.config.runCommand(this._defaultCommandId || '', [...this.argv], {isRunByDefault: true})
+    return this.config.runCommand(this._defaultCommandId || '', [...this.argv], {isBeingRunByDefault: true})
   }
 
   protected _helpOverride(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,19 +15,30 @@ export class Main extends Command {
   }
 
   async run() {
+    if (this.argv.length === 0) {
+      if (this._defaultCommandId) return this._runDefaultCommand()
+      return this._help()
+    }
     const [id, ...argv] = this.argv
     this.parse({strict: false, '--': false, ...this.ctor as any})
     if (!this.config.findCommand(id)) {
       const topic = this.config.findTopic(id)
       if (topic) return this._help()
+      if (this._defaultCommandId) return this._runDefaultCommand()
     }
     await this.config.runCommand(id, argv)
   }
 
+  protected _runDefaultCommand() {
+    return this.config.runCommand(this._defaultCommandId || '', [...this.argv], {isRunByDefault: true})
+  }
+
   protected _helpOverride(): boolean {
+    if (this.argv.length === 0) {
+      return !this._defaultCommandId
+    }
     if (['-v', '--version', 'version'].includes(this.argv[0])) return this._version() as any
     if (['-h', 'help'].includes(this.argv[0])) return true
-    if (this.argv.length === 0) return true
     for (const arg of this.argv) {
       if (arg === '--help') return true
       if (arg === '--') return false


### PR DESCRIPTION
https://github.com/oclif/oclif/issues/277

A command can now be designated as the default command (via
package.json -> "oclif": {"defaultCommand": "<cmdId>"}).
When a default command is specified, oclif will attempt to run
that command when it doesn't recognize the command in the input,
or when the input doesn't contain a command, or when
there are no arguments passed to the CLI.

This allows for a command to behave similarly to `yarn [run] <script>`,
where `run` is the default command, such that running `yarn <script>`
does the same thing as `yarn run <script>`.