### PR TITLE
Configure 'help'/'version' command id

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,5 @@
 const pjson = require('../package.json')
+
 import * as Config from '@oclif/config'
 import * as Errors from '@oclif/errors'
 import * as Parser from '@oclif/parser'
@@ -159,6 +160,28 @@ export default abstract class Command {
     return require('@oclif/parser').parse(argv, {context: this, ...options})
   }
 
+  protected get _versionCommandId() {
+    let commandId = (this.config.pjson.oclif as {
+      versionCommand?: string | null
+    }).versionCommand
+    if (commandId === undefined) {
+      commandId = 'version'
+    }
+    commandId = commandId || undefined
+    return commandId
+  }
+
+  protected get _helpCommandId() {
+    let commandId = (this.config.pjson.oclif as {
+      helpCommand?: string | null
+    }).helpCommand
+    if (commandId === undefined) {
+      commandId = 'help'
+    }
+    commandId = commandId || undefined
+    return commandId
+  }
+
   protected async catch(err: any): Promise<any> {
     if (!err.message) throw err
     if (err.message.match(/Unexpected arguments?: (-h|--help|help)(,|\n)/)) {
@@ -198,10 +221,16 @@ export default abstract class Command {
     return this.exit(0)
   }
 
+  protected get _helpOverrideArgs() {
+    return ['--help']
+  }
+
   protected _helpOverride(): boolean {
     for (const arg of this.argv) {
-      if (arg === '--help') return true
       if (arg === '--') return false
+      if (this._helpOverrideArgs.includes(arg)) {
+        return true
+      }
     }
     return false
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,15 +24,27 @@ export class Main extends Command {
     await this.config.runCommand(id, argv)
   }
 
-  protected _helpOverride(): boolean {
-    if (['-v', '--version', 'version'].includes(this.argv[0])) return this._version() as any
-    if (['-h', 'help'].includes(this.argv[0])) return true
-    if (this.argv.length === 0) return true
-    for (const arg of this.argv) {
-      if (arg === '--help') return true
-      if (arg === '--') return false
+  protected get _helpAliases() {
+    const helpAlias = ['-h', '-help', '--help']
+    if (this._helpCommandId) {
+      helpAlias.push(this._helpCommandId)
     }
-    return false
+    return helpAlias
+  }
+
+  protected get _versionAliases() {
+    const versionAlias = ['-v', '-version', '--version']
+    if (this._versionCommandId) {
+      versionAlias.push(this._versionCommandId)
+    }
+    return versionAlias
+  }
+
+  protected _helpOverride(): boolean {
+    if (this._versionAliases.includes(this.argv[0])) return this._version() as any
+    if (this._helpAliases.includes(this.argv[0])) return true
+    if (this.argv.length === 0) return true
+    return super._helpOverride()
   }
 
   protected _help() {


### PR DESCRIPTION
This is if you want your CLI to use a different
command name besides the default, or if you don't
want your CLI to have a 'help'/'version' command
at all. For example, your CLI could have '_version'
be the version command instead of 'version'.

These can be configured in package.json -> oclif -> 'versionCommand'/'helpCommand'