### PR TITLE
fix: use args.Input to accept any type args

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -58,7 +58,7 @@ export default abstract class Command {
   static flags?: flags.Input<any>
 
   /** An order-dependent array of arguments for the command */
-  static args?: Parser.args.IArg[]
+  static args?: Parser.args.Input
 
   static plugin: Config.IPlugin | undefined
 


### PR DESCRIPTION
Closes oclif/oclif#337