### PR TITLE
feat: add pretty printable interface to methods on command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/oclif/command/issues",
   "dependencies": {
     "@oclif/config": "^1.15.1",
-    "@oclif/errors": "^1.3.1",
+    "@oclif/errors": "^1.3.3",
     "@oclif/parser": "^3.8.3",
     "@oclif/plugin-help": "^3",
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/oclif/command/issues",
   "dependencies": {
     "@oclif/config": "^1.15.1",
-    "@oclif/errors": "^1.2.2",
+    "@oclif/errors": "^1.3.1",
     "@oclif/parser": "^3.8.3",
     "@oclif/plugin-help": "^3",
     "debug": "^4.1.1",

--- a/src/command.ts
+++ b/src/command.ts
@@ -8,6 +8,7 @@ import {format, inspect} from 'util'
 import * as flags from './flags'
 import {sortBy, uniqBy} from './util'
 import {getHelpClass} from '@oclif/plugin-help'
+import {PrettyPrintableError} from '@oclif/errors/lib/errors/pretty-print'
 
 /**
  * swallows stdout epipe errors
@@ -122,11 +123,11 @@ export default abstract class Command {
     Errors.warn(input)
   }
 
-  error(input: string | Error, options: {code?: string; exit: false}): void
+  error(input: string | Error, options: {code?: string; exit: false} & PrettyPrintableError): void
 
-  error(input: string | Error, options?: {code?: string; exit?: number}): never
+  error(input: string | Error, options?: {code?: string; exit?: number} & PrettyPrintableError): never
 
-  error(input: string | Error, options: {code?: string; exit?: number | false} = {}) {
+  error(input: string | Error, options: {code?: string; exit?: number | false} & PrettyPrintableError = {}) {
     return Errors.error(input, options as any)
   }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -8,7 +8,7 @@ import {format, inspect} from 'util'
 import * as flags from './flags'
 import {sortBy, uniqBy} from './util'
 import {getHelpClass} from '@oclif/plugin-help'
-import {PrettyPrintableError} from '@oclif/errors/lib/errors/pretty-print'
+import {PrettyPrintableError} from '@oclif/errors'
 
 /**
  * swallows stdout epipe errors

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,17 @@
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+"@oclif/errors@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.1.tgz#297b783ea1d18e46aa28999c7e1b8b827cd8572a"
+  integrity sha512-ma9SpBNnAjbJNc8kPl8G8n6oJX0WK0FtosuJ9Y5etHoJrqq/s9GOOIxo47fSXomLT1fmqYX5cW2yeQ2Q39XyAw==
+  dependencies:
+    clean-stack "^3.0.0"
+    fs-extra "^9.0.1"
+    indent-string "^4.0.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 "@oclif/linewrap@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/errors@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.1.tgz#297b783ea1d18e46aa28999c7e1b8b827cd8572a"
-  integrity sha512-ma9SpBNnAjbJNc8kPl8G8n6oJX0WK0FtosuJ9Y5etHoJrqq/s9GOOIxo47fSXomLT1fmqYX5cW2yeQ2Q39XyAw==
+"@oclif/errors@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.3.tgz#fb597dfbc58c6b8609dc0b2fdf91a2d487818a82"
+  integrity sha512-EJR6AIOEkt/NnARNIVAskPDVtdhtO5TTNXmhDrGqMoWVsr0R6DkkLrMyq95BmHvlVWM1nduoq4fQPuCyuF2jaA==
   dependencies:
     clean-stack "^3.0.0"
     fs-extra "^9.0.1"


### PR DESCRIPTION
This pull requests adds the interfaces for pretty printable options on `this.error`. This makes annotating the errors easier and fixes any typescript warnings that may arise.