### PR TITLE
fix parse F constraint

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -156,7 +156,7 @@ export default abstract class Command {
     if (this._helpOverride()) return this._help()
   }
 
-  protected parse<F, A extends {[name: string]: any}>(options?: Parser.Input<F>, argv = this.argv): Parser.Output<F, A> {
+  protected parse<F extends flags.Output, A extends {[name: string]: any}>(options?: Parser.Input<F>, argv = this.argv): Parser.Output<F, A> {
     if (!options) options = this.constructor as any
     return require('@oclif/parser').parse(argv, {context: this, ...options})
   }


### PR DESCRIPTION
This makes it compatible with TypeScript 4.8

before this change you get an error:

```
packages/app/node_modules/@oclif/command/lib/command.d.ts:70:31 - error TS2344: Type 'F' does not satisfy the constraint 'Output'.

70     }>(options?: Parser.Input<F>, argv?: string[]): Parser.Output<F, A>;
                                 ~
```