### PR TITLE
fix: use scopedEnvVarKeys for bin aliases

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -103,7 +103,7 @@ export default abstract class Command {
     let err: Error | undefined
     try {
       // remove redirected env var to allow subsessions to run autoupdated client
-      delete process.env[this.config.scopedEnvVarKey('REDIRECTED')]
+      this.config.scopedEnvVarKeys('REDIRECTED').map(k => delete process.env[k])
 
       await this.init()
       return await this.run()


### PR DESCRIPTION
@W-13825184@
requires: https://github.com/oclif/core/pull/751